### PR TITLE
Support dependencies between packages in monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Note: If you already have other buildpacks defined, you'll need to make sure tha
 
 # Authors
 
-Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com> and now Lincoln Stoll <lstoll@heroku.com>
+Andrew Gwozdziewycz <apg@heroku.com> and Cyril David <cyx@heroku.com> and now Lincoln Stoll <lstoll@heroku.com> and Jan Tietze <jan@tietze.io>

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Note: If you already have other buildpacks defined, you'll need to make sure tha
 
 ## Local dependencies
 
-If you have local dependencies (e.g. a lerna monorepo with "file://../packagename" style dependencies pointing to packages contained in the same repo, exactly one level above your repository) you can add them using the DEPENDENCIES build var. E.g.
+If you have local dependencies (e.g. a lerna monorepo with `file:../packagename` style dependencies pointing to packages contained in the same repo, *exactly one level above your package*) you can add them using the DEPENDENCIES build var. E.g.
 
 1. `APP_BASE=packages/frontend`
-2. `DEPENDENCIES=packages/shared packages/util`
+2. `DEPENDENCIES=packages/shared packages/util` to include two packages, `packages/shared` and `packages/util`.
 
 would add `packages/shared` and `packages/util` to one level above the Heroku `BUILD_DIR` and make them available for the build process.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ Enter the Monorepo buildpack, which is a copy of [heroku-buildpack-multi-procfil
    `heroku buildpacks:add -a <app> https://github.com/lstoll/heroku-buildpack-monorepo`
 4. For each app, `git push git@heroku.com:<app> master`
 
-Note: If you already have other buildpacks defined, you'll need to make sure that the heroku-buildpack-monorepo buildpack is defined first. You can do this by adding `-i 1` to the `heroku buildpacks:add` command.
+Note: If you already have other buildpacks defined, you'll need to make sure that the heroku-buildpack-monorepo buildpack is defined first. You can do this by adding `-i 1` to the `heroku buildpacks:add` command or changing the buildpack order visually in the application settings under "buildpacks" in the Heroku dashboard.
+
+## Local dependencies
+
+If you have local dependencies (e.g. a lerna monorepo with "file://../packagename" style dependencies pointing to packages contained in the same repo, exactly one level above your repository) you can add them using the DEPENDENCIES build var. E.g.
+
+1. `APP_BASE=packages/frontend`
+2. `DEPENDENCIES=packages/shared packages/util`
+
+would add `packages/shared` and `packages/util` to one level above the Heroku `BUILD_DIR` and make them available for the build process.
 
 # Authors
 

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ fi
                 exit 1
             fi
             echo "Lifting dependency ${DEPENDENCY} to ${BUILD_DIR}/${DEPENDENCY}." | indent | indent
-            mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../"
+            mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../$(basename "$DEPENDENCY)"
         done
     fi &&
     rm -rf "${BUILD_DIR}" &&

--- a/bin/compile
+++ b/bin/compile
@@ -29,6 +29,7 @@ fi
                 echo "Dependency ${DEPENDENCY} not found. Aborting" | indent
                 exit 1
             fi
+            echo "Copied dependency ${DEPENDENCY}."
             mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../"
         done
     fi &&

--- a/bin/compile
+++ b/bin/compile
@@ -20,8 +20,6 @@ else
     DEPENDENCIES="$(cat "${ENV_DIR}/DEPENDENCIES")"
 fi
 
-APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
-
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
     if [ ! -z "$DEPENDENCIES" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ fi
                 exit 1
             fi
             echo "Lifting dependency ${DEPENDENCY} to ${BUILD_DIR}/${DEPENDENCY}." | indent | indent
-            mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../$(basename "$DEPENDENCY)"
+            mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../$(basename "$DEPENDENCY")"
         done
     fi &&
     rm -rf "${BUILD_DIR}" &&

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
                 echo "Dependency ${DEPENDENCY} not found. Aborting" | indent
                 exit 1
             fi
-            echo "Copied dependency ${DEPENDENCY}."
+            echo "Lifting dependency ${DEPENDENCY} to ${BUILD_DIR}/${DEPENDENCY}." | indent | indent
             mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../"
         done
     fi &&

--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ fi
             fi
             TARGET="${BUILD_DIR}/../$(basename "$DEPENDENCY")"
             echo "Lifting dependency ${DEPENDENCY} from '${BUILD_DIR}/${DEPENDENCY}' to '${TARGET}'." | indent | indent
-            mv "${BUILD_DIR}/${DEPENDENCY}" "${TARGET}"
+            mv -v "${BUILD_DIR}/${DEPENDENCY}" "${TARGET}"
         done
     fi &&
     rm -rf "${BUILD_DIR}" &&

--- a/bin/compile
+++ b/bin/compile
@@ -29,8 +29,9 @@ fi
                 echo "Dependency ${DEPENDENCY} not found. Aborting" | indent
                 exit 1
             fi
-            echo "Lifting dependency ${DEPENDENCY} to ${BUILD_DIR}/${DEPENDENCY}." | indent | indent
-            mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../$(basename "$DEPENDENCY")"
+            TARGET="${BUILD_DIR}/../$(basename "$DEPENDENCY")"
+            echo "Lifting dependency ${DEPENDENCY} from '${BUILD_DIR}/${DEPENDENCY}' to '${TARGET}'." | indent | indent
+            mv "${BUILD_DIR}/${DEPENDENCY}" "${TARGET}"
         done
     fi &&
     rm -rf "${BUILD_DIR}" &&

--- a/bin/compile
+++ b/bin/compile
@@ -14,8 +14,11 @@ if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
 fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
+DEPENDENCY="packages/get-coffee-util"
+
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
+    mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../"
     rm -rf "${BUILD_DIR}" &&
     mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
 )

--- a/bin/compile
+++ b/bin/compile
@@ -14,19 +14,33 @@ if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
 fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
-DEPENDENCY="packages/get-coffee-util"
+if [ ! -f "${ENV_DIR}/DEPENDENCIES" ]; then
+    echo "No dependencies configured. If you wish to include local packages in monorepo with '../<package>' style depencies, set DEPENDENCIES." | indent
+else
+    DEPENDENCIES="$(cat "${ENV_DIR}/DEPENDENCIES")"
+fi
+
+APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../"
+    if [ ! -z "$DEPENDENCIES" ]; then
+        echo "Processing dependencies" | indent
+        for DEPENDENCY in ${DEPENDENCIES}; do
+            if [ ! -d "${BUILD_DIR}/${DEPENDENCY}" ]; then
+                echo "Dependency ${DEPENDENCY} not found. Aborting" | indent
+                exit 1
+            fi
+            mv "${BUILD_DIR}/${DEPENDENCY}" "${BUILD_DIR}/../"
+        done
+    fi &&
     rm -rf "${BUILD_DIR}" &&
     mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
 )
 
 if [ $? -ne 0 ]; then
-    echo "FAILED to copy directory into place" | indent
+    echo "FAILED to copy directories into place" | indent
     exit 1
 fi
 
 echo "Copied ${APP_BASE} to root of app successfully" | indent
-


### PR DESCRIPTION
Issue #7 explains the issue (when there is a dependency between several packages in a monorepo, build fails). This PR solves the issue for (at least) Node.