### PR TITLE
Copy siblings of APP_BASE next to APP_BASE

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,8 +18,13 @@ if [ ! -f "${ENV_DIR}/APP_BASE" ]; then
 fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
+BUILD_PARENT_DIR=$(builtin cd "$BUILD_DIR/.."; pwd)
+APP_BASE_PARENT=$(builtin cd "${BUILD_DIR}/${APP_BASE}/.."; pwd)
+
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
+    ls $APP_BASE_PARENT &&
+    mv $APP_BASE_PARENT/* "${BUILD_PARENT_DIR}/" &&
     rm -rf "${BUILD_DIR}"/* &&
     mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}"
 )


### PR DESCRIPTION
This allows to have relative links at least with `npm`, I haven't tried with other package managers/languages.

This should partially fix issue #7.